### PR TITLE
```plaintext

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,7 @@
 
     <profiles>
         <profile>
-            <id>release-parent</id>
+            <id>release</id>
             <build>
                 <plugins>
                     <plugin>


### PR DESCRIPTION
refactor(pom): rename Maven profile id to release (development)

Changed the Maven profile id from release-parent to release for improved clarity and consistency in the build process configuration.
```