### PR TITLE
```plaintext

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,9 +38,9 @@
     </licenses>
 
     <scm>
-        <connection>scm:git:git://github.com/quartz-framework/quartz-starter.git</connection>
-        <developerConnection>scm:git:ssh://github.com/quartz-framework/quartz-starter.git</developerConnection>
-        <url>https://github.com/quartz-framework/quartz-starter/tree/main</url>
+        <connection>scm:git:git://github.com/quartz-framework/quartz-framework.git</connection>
+        <developerConnection>scm:git:ssh://github.com/quartz-framework/quartz-framework.git</developerConnection>
+        <url>https://github.com/quartz-framework/quartz-framework/tree/main</url>
     </scm>
 
     <properties>


### PR DESCRIPTION
fix(pom): update SCM URLs to correct repository (development)

Corrected the SCM connection URLs in the pom.xml to point to the quartz-framework repository instead of quartz-starter, ensuring accuracy in repository references.
```