### PR TITLE
```plaintext

### DIFF
--- a/quartz-beans/src/main/java/xyz/quartzframework/beans/condition/Evaluators.java
+++ b/quartz-beans/src/main/java/xyz/quartzframework/beans/condition/Evaluators.java
@@ -83,9 +83,8 @@ public final class Evaluators {
             val metadata = def.getPropertyConditionMetadata();
             if (metadata == null) return true;
             val env = factory.getBean(PropertyPostProcessor.class);
-            val property = metadata.getProperty();
-            val expression = property.getAttribute("value", String.class);
-            val source = property.getAttribute("source", String.class);
+            val expression = metadata.getExpression();
+            val source = metadata.getSource();
             val value = env.process(expression, source, String.class);
             return Objects.equals(value, metadata.getExpected());
         });

--- a/quartz-beans/src/main/java/xyz/quartzframework/beans/condition/metadata/PropertyConditionMetadata.java
+++ b/quartz-beans/src/main/java/xyz/quartzframework/beans/condition/metadata/PropertyConditionMetadata.java
@@ -7,23 +7,27 @@ import lombok.val;
 import xyz.quartzframework.beans.definition.metadata.AnnotationMetadata;
 import xyz.quartzframework.beans.definition.metadata.TypeMetadata;
 import xyz.quartzframework.beans.support.annotation.condition.ActivateWhenPropertyEquals;
+import xyz.quartzframework.config.Property;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class PropertyConditionMetadata {
 
-    private AnnotationMetadata property;
+    private String expression;
 
     private String expected;
+
+    private String source;
 
     public static PropertyConditionMetadata of(TypeMetadata metadata) {
         return metadata
                 .getAnnotation(ActivateWhenPropertyEquals.class)
                 .map(a -> {
-                    val propertyAnnotation = a.getAnnotationAttribute("value");
+                    val expression = a.getAttribute("property", String.class);
                     val expect = a.getAttribute("expected", String.class);
-                    return new PropertyConditionMetadata(propertyAnnotation, expect);
+                    val source = a.getAttribute("source", String.class);
+                    return new PropertyConditionMetadata(expression, expect, source);
                 })
                 .orElse(null);
     }

--- a/quartz-beans/src/main/java/xyz/quartzframework/beans/support/annotation/condition/ActivateWhenPropertyEquals.java
+++ b/quartz-beans/src/main/java/xyz/quartzframework/beans/support/annotation/condition/ActivateWhenPropertyEquals.java
@@ -9,8 +9,10 @@ import java.lang.annotation.*;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ActivateWhenPropertyEquals {
 
-    Property value();
+    String expression();
 
     String expected();
+
+    String source() default "application";
 
 }


### PR DESCRIPTION
refactor: enhance property condition metadata handling (development)

Updated Evaluators to utilize the new attribute retrieval method for property conditions. Modified ActivateWhenPropertyEquals to use expression and source attributes instead of Property. Added default source value in annotation. PropertyConditionMetadata now directly uses expression, expected, and source fields, improving consistency and clarity in condition validation.
```