### PR TITLE
```plaintext

### DIFF
--- a/quartz-beans/src/main/java/xyz/quartzframework/beans/condition/ConditionType.java
+++ b/quartz-beans/src/main/java/xyz/quartzframework/beans/condition/ConditionType.java
@@ -9,8 +9,8 @@ public enum ConditionType {
     CONDITIONAL(BeanEvaluationMomentType.POST_REGISTRATION),
     ON_CLASS(BeanEvaluationMomentType.PRE_REGISTRATION),
     ON_MISSING_CLASS(BeanEvaluationMomentType.PRE_REGISTRATION),
-    ON_PROPERTY(BeanEvaluationMomentType.PRE_REGISTRATION),
-    ON_ENVIRONMENT(BeanEvaluationMomentType.PRE_REGISTRATION),
+    ON_PROPERTY(BeanEvaluationMomentType.POST_REGISTRATION),
+    ON_ENVIRONMENT(BeanEvaluationMomentType.POST_REGISTRATION),
     ON_BEAN(BeanEvaluationMomentType.POST_REGISTRATION),
     ON_MISSING_BEAN(BeanEvaluationMomentType.POST_REGISTRATION),
     ON_ANNOTATION(BeanEvaluationMomentType.POST_REGISTRATION);

--- a/quartz-beans/src/main/java/xyz/quartzframework/beans/condition/metadata/PropertyConditionMetadata.java
+++ b/quartz-beans/src/main/java/xyz/quartzframework/beans/condition/metadata/PropertyConditionMetadata.java
@@ -3,12 +3,12 @@ package xyz.quartzframework.beans.condition.metadata;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
-import xyz.quartzframework.beans.definition.metadata.AnnotationMetadata;
 import xyz.quartzframework.beans.definition.metadata.TypeMetadata;
 import xyz.quartzframework.beans.support.annotation.condition.ActivateWhenPropertyEquals;
-import xyz.quartzframework.config.Property;
 
+@Slf4j
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -24,7 +24,7 @@ public class PropertyConditionMetadata {
         return metadata
                 .getAnnotation(ActivateWhenPropertyEquals.class)
                 .map(a -> {
-                    val expression = a.getAttribute("property", String.class);
+                    val expression = a.getAttribute("expression", String.class);
                     val expect = a.getAttribute("expected", String.class);
                     val source = a.getAttribute("source", String.class);
                     return new PropertyConditionMetadata(expression, expect, source);

--- a/quartz-beans/src/main/java/xyz/quartzframework/beans/definition/DefaultBeanDefinitionRegistry.java
+++ b/quartz-beans/src/main/java/xyz/quartzframework/beans/definition/DefaultBeanDefinitionRegistry.java
@@ -93,7 +93,6 @@ public class DefaultBeanDefinitionRegistry implements QuartzBeanDefinitionRegist
     @Override
     public QuartzBeanDefinition getBeanDefinition(String beanName, TypeMetadata metadata) {
         return getBeanDefinitions()
-
                 .stream()
                 .filter(b -> b.getName().equals(beanName))
                 .filter(b -> b.getTypeMetadata().matches(metadata))

--- a/quartz-beans/src/main/java/xyz/quartzframework/beans/support/annotation/condition/ActivateWhenPropertyEquals.java
+++ b/quartz-beans/src/main/java/xyz/quartzframework/beans/support/annotation/condition/ActivateWhenPropertyEquals.java
@@ -1,7 +1,5 @@
 package xyz.quartzframework.beans.support.annotation.condition;
 
-import xyz.quartzframework.config.Property;
-
 import java.lang.annotation.*;
 
 @Documented


### PR DESCRIPTION
refactor: enhance property condition metadata handling (development)

Changed ConditionType to use POST_REGISTRATION for ON_PROPERTY and ON_ENVIRONMENT. Updated DefaultPropertyPostProcessor to improve logging and conversion logic, adding detailed trace logs and handling raw values. Modified PropertyConditionMetadata to use 'expression' attribute instead of 'property', enhancing clarity in metadata handling. Removed redundant blank line in DefaultBeanDefinitionRegistry.
```